### PR TITLE
clean up URL

### DIFF
--- a/nexus_settings.xml
+++ b/nexus_settings.xml
@@ -4,7 +4,7 @@
     <mirror>
       <id>nexus</id>
       <name>Nexus Public Mirror</name>
-      <url>https://nexus-nexus.apps.cluster-vilt.vilt.example.opentlc.com/repository/maven-all-public/</url>
+      <url>https://nexus-nexus.apps.cluster-XXXX.example.opentlc.com/repository/maven-all-public/</url>
       <mirrorOf>*</mirrorOf>
     </mirror>
   </mirrors>

--- a/nexus_settings.xml
+++ b/nexus_settings.xml
@@ -4,7 +4,7 @@
     <mirror>
       <id>nexus</id>
       <name>Nexus Public Mirror</name>
-      <url>https://nexus-nexus.apps.cluster-XXXX.example.opentlc.com/repository/maven-all-public/</url>
+      <url>https://nexus-nexus.apps.cluster-XXXX.dynamic.opentlc.com/repository/maven-all-public/</url>
       <mirrorOf>*</mirrorOf>
     </mirror>
   </mirrors>


### PR DESCRIPTION
The Nexus URL in the Maven settings file was of the old format.

Clean up here to reduce confusion.